### PR TITLE
feat: migrate ecx resources to fabric v4

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,73 @@
+locals {
+  sp_supported_bandwidths = ((var.speed == null || var.speed == 0) && var.seller_profile_name != "") ? [
+    for config in data.equinix_fabric_service_profiles.sp[0].data[0].access_point_type_configs : config.supported_bandwidths
+  ][0] : []
+
+  bandwidth = length(local.sp_supported_bandwidths) > 0 ? [
+    for s in sort(formatlist("%03d", local.sp_supported_bandwidths)) : tonumber(s) if s > 0
+  ][0] : var.speed
+
+  secondary_bandwidth = var.redundancy_type == "REDUNDANT" && (var.secondary_speed == null || var.secondary_speed == 0) ? local.bandwidth : var.secondary_speed
+
+  primary_seller_metro_code = var.seller_profile_name != "" ? var.seller_metro_code == "" ? [
+    for metro in data.equinix_fabric_service_profiles.sp[0].data[0].metros : metro.code
+    if metro.name == title(var.seller_metro_name)
+  ][0] : var.seller_metro_code : null
+
+  primary_region = var.seller_profile_name != "" ? var.seller_region == "" ? [
+    for metro in data.equinix_fabric_service_profiles.sp[0].data[0].metros : try(keys(metro.seller_regions)[0], null)
+    if metro.code == local.primary_seller_metro_code
+  ][0] : var.seller_region : null
+
+  primary_name = var.name != "" ? var.name : upper(format("%s-%s-%s", split(" ", coalesce(
+    var.seller_profile_name, var.zside_port_name
+  ))[0], local.primary_seller_metro_code, random_string.this.result))
+
+  secondary_seller_metro_code = (var.secondary_seller_metro_name != "" && var.seller_profile_name != "") ? [
+    for metro in data.equinix_fabric_service_profiles.sp[0].data[0].metros : metro.code
+    if metro.name == title(var.secondary_seller_metro_name)
+  ][0] : var.secondary_seller_metro_code != "" ? var.secondary_seller_metro_code : local.primary_seller_metro_code
+
+  secondary_name      = var.secondary_name != "" ? var.secondary_name : format("%s-SEC", local.primary_name)
+  secondary_port_uuid = var.secondary_port_name != "" ? data.equinix_fabric_ports.secondary[0].data[0].uuid : null
+
+  notification_users_by_type = length(var.notification_users) > 0 ? merge(
+    var.notification_users_by_type,
+    {
+      "ALL" = contains(keys(var.notification_users_by_type), "ALL") ? distinct(
+        concat(var.notification_users_by_type["ALL"], var.notification_users)
+      ) : var.notification_users
+    }
+  ) : var.notification_users_by_type
+
+  // TODO (ocobles) consider VG, IGW, SUBNET, GW use cases
+  // TODO (ocobles) replace aside_ap_type line below to support FCR
+  # aside_ap_type = var.network_edge_id != "" ? "VD" : var.cloud_router_id != "" ? "CLOUD_ROUTER" : "COLO"
+  aside_ap_type = var.network_edge_id != "" ? "VD" : "COLO"
+  // TODO (ocobles) replace zside_ap_type line below to support Fabric Network
+  # zside_ap_type = (var.zside_port_name != "" || var.zside_service_token_id != "")  ? "COLO" : var.network_id != "" ? "NETWORK" : "SP"
+  zside_ap_type = (var.zside_port_name != "" || var.zside_service_token_id != "")  ? "COLO" : "SP"
+
+  link_protocol_type = var.port_name != "" ? one(data.equinix_fabric_ports.primary[0].data.0.encapsulation).type : ""
+  secondary_link_protocol_type = var.redundancy_type == "REDUNDANT" && var.port_name != "" ? one(data.equinix_fabric_ports.secondary[0].data.0.encapsulation).type : ""
+  zside_link_protocol_type = var.zside_port_name != "" ? one(data.equinix_fabric_ports.zside[0].data.0.encapsulation).type : ""
+
+  connection_type = var.connection_type != "" ? var.connection_type : (
+      local.link_protocol_type == "UNTAGGEDEPL" && local.zside_link_protocol_type == "UNTAGGEDEPL"
+    ) ? "EPL_VC" : (
+      (local.link_protocol_type == "QINQ" && local.zside_link_protocol_type == "UNTAGGEDEPL") ||
+      (local.link_protocol_type == "UNTAGGEDEPL" && local.zside_link_protocol_type == "QINQ")
+    ) ? "ACCESS_EPL_VC" : "EVPL_VC" # Default value EVPL_VC should cover use cases: COLO2COLO, COLO2SP, VD2COLO, VD2COLO(TOKEN), COLO(TOKEN)2SP
+  #   // TODO (ocobles) replace last ACCESS_EPL_VC condition with below code to support FCR and Fabric Network
+  #   # ) ? "ACCESS_EPL_VC" : (
+  #   # local.aside_ap_type == "CLOUD_ROUTER" && (local.zside_ap_type == "COLO" || local.zside_ap_type == "SP")
+  #   # ) ? "IP_VC" : (
+  #   # local.aside_ap_type == "CLOUD_ROUTER" && local.zside_ap_type == "NETWORK"
+  #   # ) ? "IPWAN_VC" : (
+  #   # local.aside_ap_type == "VD" && local.zside_ap_type == "NETWORK"
+  #   # ) ? "EVPLAN_VC" : (
+  #   # local.aside_ap_type == "COLO" && local.zside_ap_type == "NETWORK" && local.link_protocol_type != "UNTAGGED"
+  #   # ) ? "EVPLAN_VC" : (
+  #   # local.aside_ap_type == "COLO" && local.zside_ap_type == "NETWORK" && local.link_protocol_type == "UNTAGGED"
+  #   # ) ? "EPLAN_VC" : "EVPL_VC" # Default value EVPL_VC should cover use cases: COLO2COLO, COLO2SP, VD2COLO, VD2COLO(TOKEN), COLO(TOKEN)2SP
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "primary_connection" {
   description = "Primary connection data."
-  value       = equinix_ecx_l2_connection.this
+  value       = equinix_fabric_connection.primary
 }
 
 output "secondary_connection" {
   description = "Secondary connection data."
-  value       = try(equinix_ecx_l2_connection.this.secondary_connection[0], null)
+  value       = try(equinix_fabric_connection.secondary, null)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,14 @@
+variable "connection_type" {
+  type        = string
+  description = <<EOF
+  Defines the connection type like EVPL_VC, EPL_VC, IP_VC, ACCESS_EPL_VC, IA_VC, EVPLAN_VC,
+  EPLAN_VC, IPWAN_VC. If not specified, it will be inferred based on access point types.
+  In cases where the type cannot be identified based on these parameters, the default value will
+  be 'EVPL_VC'.
+  EOF
+  default     = ""
+}
+
 variable "seller_profile_name" {
   type        = string
   description = <<EOF
@@ -19,7 +30,7 @@ variable "name" {
 variable "port_name" {
   type        = string
   description = <<EOF
-  Name of the buyer's port from which the connection would originate. One of 'port_name',
+  Name of the buyer's port from which the primary connection would originate. One of 'port_name',
   'network_edge_id' or 'service_token_id' is required.
   EOF
   default     = ""
@@ -36,14 +47,18 @@ variable "speed" {
 
 variable "speed_unit" {
   type        = string
-  description = "Unit of the speed/bandwidth to be allocated to the connection."
+  description = <<EOF
+  DEPRECATED and IGNORED: This variable is no longer used as speed is always assumed to be in MB
+  (megabytes). Specifying this variable will have no effect.
+  EOF
   default     = ""
 
   validation {
-    condition = (
-      var.speed_unit == "" ? true : contains(["GB", "MB"], var.speed_unit)
-    )
-    error_message = "Valid values are (MB, GB)."
+    condition     = var.speed_unit == ""
+    error_message = <<EOF
+    The 'speed_unit' variable is deprecated and should not be set. Please remove this variable
+    from your configuration.
+    EOF
   }
 }
 
@@ -94,11 +109,45 @@ variable "seller_region" {
 
 variable "notification_users" {
   type        = list(string)
-  description = "A list of email addresses used for sending connection update notifications."
+  description = <<EOF
+  A list of email addresses used to notify all connection configuration or status changes. One of
+  'notification_users' or 'notification_users_by_type' is required. This is equivalent to adding a
+  list to 'notification_users_by_type' with the key type ALL.
+  EOF
 
   validation {
     condition     = length(var.notification_users) > 0
     error_message = "Notification list cannot be empty."
+  }
+}
+
+variable "notification_users_by_type" {
+  type = map(list(string))
+
+  description = <<EOF
+  A map where each key represents a notification type (e.g., 'BANDWIDTH_ALERT', 'ALL') and the
+  value is a list of email addresses. This structure allows for the categorization of email
+  addresses based on the type of notification they should receive. One of
+  'notification_users_by_type' or 'notification_users' is required. Valid map keys are: ALL,
+  BANDWIDTH_ALERT, CONNECTION_APPROVAL, PROFILE_LIFECYCLE, SALES_REP_NOTIFICATIONS.
+  EOF
+  default     = {}
+
+  validation {
+    condition     = alltrue([
+      for k, _ in var.notification_users_by_type :
+      contains([
+        "ALL",
+        "BANDWIDTH_ALERT",
+        "CONNECTION_APPROVAL",
+        "PROFILE_LIFECYCLE",
+        "SALES_REP_NOTIFICATIONS"
+      ], k )
+    ])
+    error_message = <<EOF
+    Valid map keys are (ALL, BANDWIDTH_ALERT, CONNECTION_APPROVAL, PROFILE_LIFECYCLE,
+    SALES_REP_NOTIFICATIONS).
+    EOF
   }
 }
 
@@ -111,8 +160,8 @@ variable "purchase_order_number" {
 variable "vlan_stag" {
   type        = number
   description = <<EOF
-  S-Tag/Outer-Tag of the primary connection - a numeric character ranging from 2 - 4094. Required
-  if 'port_name' is specified.
+  VLAN S-Tag/Outer-Tag information for QINQ connections, or VLAN Tag information for DOT1Q.
+  Required if 'port_name' (A side). A numeric character ranging from 2 - 4094.
   EOF
   default     = 0
 }
@@ -120,8 +169,7 @@ variable "vlan_stag" {
 variable "vlan_ctag" {
   type        = number
   description = <<EOF
-  C-Tag/Inner-Tag of the primary connection - a numeric character ranging from
-  2 - 4094.
+  VLAN C-Tag/Inner-Tag information for QINQ connections. A numeric character ranging from 2 - 4094.
   EOF
   default     = 0
 }
@@ -140,8 +188,8 @@ variable "zside_port_name" {
 variable "zside_vlan_stag" {
   type        = number
   description = <<EOF
-  S-Tag/Outer-Tag of the connection on the Z side. Required if 'zside_port_name' is specified. A
-  numeric character ranging from 2 - 4094.
+  VLAN S-Tag/Outer-Tag information for QINQ connections, or VLAN Tag information for DOT1Q.
+  Required if 'zside_port_name' (Z side). A numeric character ranging from 2 - 4094.
   EOF
   default     = 0
 }
@@ -149,8 +197,7 @@ variable "zside_vlan_stag" {
 variable "zside_vlan_ctag" {
   type        = number
   description = <<EOF
-  C-Tag/Inner-Tag of the connection on the Z side. This is only applicable with 'named_tag'. A
-  numeric character ranging from 2 - 4094.
+  VLAN C-Tag/Inner-Tag information for QINQ connections. A numeric character ranging from 2 - 4094.
   EOF
   default     = 0
 }
@@ -171,7 +218,7 @@ variable "additional_info" {
     })
   )
   description = <<EOF
-  Additional parameters required for some service profiles. It should be a list of maps containing
+  Additional parameters required for some connections. It should be a list of maps containing
   'name' and 'value  e.g. `[{ name='asn' value = '65000'}, { name='ip' value = '192.168.0.1'}]`.
   EOF
   default     = []
@@ -258,24 +305,25 @@ variable "secondary_speed" {
 variable "secondary_speed_unit" {
   type        = string
   description = <<EOF
-  Unit of the speed/bandwidth to be allocated to the secondary connection. If not specified then
-  primary connection speed unit will be used.
+  DEPRECATED and IGNORED: This variable is no longer used as speed is always assumed to be in MB
+  (megabytes). Specifying this variable will have no effect.
   EOF
   default     = ""
 
   validation {
-    condition = (
-      var.secondary_speed_unit == "" ? true : contains(["GB", "MB"], var.secondary_speed_unit)
-    )
-    error_message = "Valid values are (MB, GB)."
+    condition     = var.speed_unit == ""
+    error_message = <<EOF
+    The 'secondary_speed_unit' variable is deprecated and should not be set. Please remove this
+    variable from your configuration.
+    EOF
   }
 }
 
 variable "secondary_vlan_stag" {
   type        = number
   description = <<EOF
-  S-Tag/Outer-Tag of the secondary connection. A numeric character ranging from 2 - 4094. Required
-  if 'secondary_port_name' is specified. 
+  VLAN S-Tag/Outer-Tag information for QINQ secondary connections, or VLAN Tag information for
+  DOT1Q. Required if 'secondary_port_name' (A side). A numeric character ranging from 2 - 4094.
   EOF
   default     = 0
 }
@@ -283,7 +331,7 @@ variable "secondary_vlan_stag" {
 variable "secondary_vlan_ctag" {
   type        = number
   description = <<EOF
-  C-Tag/Inner-Tag of the secondary connection - a numeric character ranging from
+  VLAN C-Tag/Inner-Tag information for QINQ secondary connections. A numeric character ranging from
   2 - 4094.
   EOF
   default     = 0
@@ -356,8 +404,43 @@ variable "secondary_service_token_id" {
   type        = string
   description = <<EOF
   Unique Equinix Fabric key shared with you by a provider that grants you authorization to use
-  their interconnection asset from (a-side) which the secondary connection would originate. Required if
-  'service_token_id' is specified, and 'redundancy_type' is 'REDUNDANT'.
+  their interconnection asset from (a-side) which the secondary connection would originate.
+  Required if 'service_token_id' is specified, and 'redundancy_type' is 'REDUNDANT'.
   EOF
   default     = ""
 }
+
+variable "secondary_zside_service_token_id" {
+  type        = string
+  description = <<EOF
+  Unique Equinix Fabric key shared with you by a provider that grants you authorization to use
+  their interconnection asset to (z-side) which the secondary connection would arrive.
+  EOF
+  default     = ""
+}
+
+// TODO (ocobles) add code below to support Fabric Network and FCR
+
+# variable "network_id" {
+#   type        = string
+#   description = "Unique identifier of a target Fabric Network."
+#   default     = ""
+# }
+
+# variable "cloud_router_id" {
+#   type        = string
+#   description = <<EOF
+#   Unique identifier of a Fabric Clour Router from which the connection would originate.
+#   EOF
+#   default     = ""
+# }
+
+# variable "cloud_router_secondary_id" {
+#   type        = string
+#   description = <<EOF
+#   Unique identifier of a Fabric Clour Router from which the connection would originate. If not
+#   specified, and 'cloud_router_id' is specified, and 'redundancy_type' is 'REDUNDANT' then primary
+#   Fabric Cloud Router will be used.
+#   EOF
+#   default     = ""
+# }

--- a/variables.tf
+++ b/variables.tf
@@ -311,7 +311,7 @@ variable "secondary_speed_unit" {
   default     = ""
 
   validation {
-    condition     = var.speed_unit == ""
+    condition     = var.secondary_speed_unit == ""
     error_message = <<EOF
     The 'secondary_speed_unit' variable is deprecated and should not be set. Please remove this
     variable from your configuration.


### PR DESCRIPTION
migrated resources:
- data "equinix_ecx_l2_sellerprofile"  --> data "equinix_fabric_service_profiles"
- data "equinix_ecx_port"  --> data "equinix_fabric_ports"
- resource "equinix_ecx_l2_connection" --> resource "equinix_fabric_connection"

Although it might be possible to split this into smaller PRs, the primary complexity lies in the migration of the `equinix_fabric_connection` resource, which requires a full migration at once. Considering the complexity, I'll outline the key points below:

- The input/output variables have been kept compatible to avoid necessitating a major release. Some optional variables have been added, and two have been deprecated (speed_unit and secondary_speed_unit).
- I've moved the local variables to a separate file for better readability.
- This module simplifies the creation of fabric v4 connections through the inference of some complex fields, such as `connection.type`, `access_point.type` and `access_point.link_protocol.type`.
While the functionality to support FCR and Fabric Network is already defined, I've left that code commented out with a TODO to add it in future releases.

This approach ensures minimal disruption